### PR TITLE
rip を 元に 実行する箇所のアセンブリコードを表示する

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,0 +1,4 @@
+all:
+	python3 de_ctl.py
+
+.PHONY: all

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -41,7 +41,7 @@ clean:
 PHONY	+=	fclean
 fclean: clean
 	rm -rf $(OBJS_DIR)
-	rm -f $(NAME)
+	rm -f $(NAME) $(TARGET)
 
 PHONY	+=	re
 re: fclean all

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -23,13 +23,13 @@ DEPENDS			:=		$(patsubst $(SRCS_DIR)%, $(OBJS_DIR)%, $(SRCS:%.c=%.d))
 PHONY	:=	all
 all: $(NAME) $(TARGET)
 
-$(NAME): $(OBJS)
+$(NAME): $(OBJS) Makefile
 	$(CC) $(CFLAGS) $(INCLUDE) $(OBJS) $(LIBS) -o $(NAME)
 
-$(TARGET): target.c
+$(TARGET): target.c Makefile
 	$(CC) $(CFLAGS) -no-pie -mno-red-zone -g3 -o $(TARGET) target.c
 
-$(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c
+$(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c Makefile
 	mkdir -p $(@D)
 	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
 

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -27,7 +27,7 @@ $(NAME): $(OBJS)
 	$(CC) $(CFLAGS) $(INCLUDE) $(OBJS) $(LIBS) -o $(NAME)
 
 $(TARGET): target.c
-	$(CC) $(CFLAGS) -no-pie -o $(TARGET) target.c
+	$(CC) $(CFLAGS) -no-pie -g3 -o $(TARGET) target.c
 
 $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c
 	mkdir -p $(@D)

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -27,7 +27,7 @@ $(NAME): $(OBJS)
 	$(CC) $(CFLAGS) $(INCLUDE) $(OBJS) $(LIBS) -o $(NAME)
 
 $(TARGET): target.c
-	$(CC) $(CFLAGS) -no-pie -g3 -o $(TARGET) target.c
+	$(CC) $(CFLAGS) -no-pie -mno-red-zone -g3 -o $(TARGET) target.c
 
 $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c
 	mkdir -p $(@D)

--- a/backend/de_ctl.py
+++ b/backend/de_ctl.py
@@ -17,7 +17,8 @@ def get_objdump_output(path) -> str:
 def show_asm_code(rip, objdump_output_splited, output_range=5):
     idx = 0
     for line in objdump_output_splited:
-        if str(hex(rip))[2:] in line:
+        # TODO : "  " objdump の 出力に依存している ちゃんとパースして消す
+        if "  " + str(hex(rip))[2:] in line:
             start = max(0, idx - output_range)
             end = min(len(objdump_output_splited), idx + output_range + 1)
             for i in range(start, end):
@@ -25,6 +26,7 @@ def show_asm_code(rip, objdump_output_splited, output_range=5):
                     print(f"==> {objdump_output_splited[i]}")
                 else:
                     print(f"    {objdump_output_splited[i]}")
+            return
         idx += 1
 
 

--- a/backend/de_ctl.py
+++ b/backend/de_ctl.py
@@ -10,16 +10,16 @@ def make() -> bool:
 
 
 def get_objdump_output(path) -> str:
-    proc = subprocess.run(f"objdump -D -M intel {path}", shell=True, stdout=subprocess.PIPE)
+    proc = subprocess.run(f"objdump -DS -M intel {path}", shell=True, stdout=subprocess.PIPE)
     return proc.stdout.decode()
 
 
-def show_asm_code(rip, objdump_output_splited):
+def show_asm_code(rip, objdump_output_splited, output_range=5):
     idx = 0
     for line in objdump_output_splited:
         if str(hex(rip))[2:] in line:
-            start = max(0, idx - 3)
-            end = min(len(objdump_output_splited), idx + 3 + 1)
+            start = max(0, idx - output_range)
+            end = min(len(objdump_output_splited), idx + output_range + 1)
             for i in range(start, end):
                 if i == idx:
                     print(f"==> {objdump_output_splited[i]}")


### PR DESCRIPTION
<img width="846" alt="Screen Shot 2023-01-26 at 20 42 25" src="https://user-images.githubusercontent.com/77755127/214827259-aeabf86b-8f1e-4f34-ab91-48286f58deb9.png">


## 変更内容

- objdump で アセンブリコード取得
- rip を 元に 実行する箇所のコードを表示
- objdump -S オプションで c src code の情報 も 表示中、邪魔だったら消すかも
- ちゃんとスタック拡張して欲しいので、(RBP - RSP の 間はメモリの中身も表示するようにしたいので) `-mno-red-zone` オプションで red ゾーンを使用しないようにしてる

## なぜ変更したか

- アセンブリコードを表示したいから。

## 動作確認の方法、動作確認した内容

- バックエンド コンテナに入って、make で 実行、最初に `s` で single step 実行が始まる ( 以降 は Enter のみで OK)


## その他、レビューで確認してほしいことなど

- デバッグターゲットの objdump の 出力を元にしているため、標準ライブラリなど、実行ファイルに含まれない部分のアセンブリコードが出力できない。
