### PR TITLE
frontendのnode_modulesのマウント方法を変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 version: '3'
+volumes:
+  node_modules:
 services:
   frontend:
     build: frontend
@@ -7,6 +9,7 @@ services:
       - 3000:3000
     volumes:
       - ./frontend:/workdir
+      - node_modules:/workdir/node_modules
     command: npm run dev
 
   backend:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,7 +7,9 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
+node_modules/**
+# dockerのvolume作成時にrootがディレクトリを作るのを防ぐ
+!node_modules/.gitkeep
 dist
 dist-ssr
 *.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,11 @@
-FROM node
+FROM node:18-slim
+
+USER node
 
 WORKDIR /workdir
+RUN chown node:node /workdir
 
-COPY package*.json ./
+COPY --chown=node:node package*.json ./
 
 RUN npm i
 


### PR DESCRIPTION
## やったこと
- イメージサイズ削減のためnodeのベースイメージをnode:18-slimに変更
- コンテナのビルドユーザーをnode（コンテナの実行ユーザー）に変更
- 空の名前付きvolumeを/workdir/node_modulesにマウント（ビルド時のnode_modulesが残る
- ↑のvolumeマウントするとホストにrootのnode_modulesが出来ちゃうので、リポジトリにnode_modulesの空ディレクトリ追加

## できるようになること
- コンテナからはビルド時のnode_modulesがみえる
- ホストのnode_modulesは実行時には使われない
- ホスト、コンテナどちらからもソースファイルの編集ができる
- ...はず

macでテストおねがいー