### PR TITLE
Feature/pre commitでclang format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-all:
+HOOKS_DIR := hooks
+GIT_HOOKS_DIR := .git/hooks
+HOOKS := $(shell find $(HOOKS_DIR) -type f)
+GIT_HOOKS := $(HOOKS:$(HOOKS_DIR)%=$(GIT_HOOKS_DIR)%)
+
+all: $(GIT_HOOKS)
 	docker compose up --build
 
 down:
@@ -11,5 +16,8 @@ backend-it:
 	docker exec -it backend bash
 
 re: down all
+
+$(GIT_HOOKS_DIR)/%: $(HOOKS_DIR)/%
+	cp $< $@
 
 .PHONY: all down re frontend-it backend-it

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+## clang-format
+# ターゲットになるc,hファイルは/backend内にあることを期待している
+host_path=`git diff --staged --name-only | grep -E ".+\.(c|h)"`
+target=`echo $host_path | sed -e "s/backend\///g"`
+
+if [ -z $target ]; then
+  exit 0
+fi
+
+echo "clang-format target:" $target
+
+docker run \
+  --rm \
+  -v "$(pwd)/backend:/workdir" \
+  -w /workdir \
+  --user "$(id -u):$(id -g)" \
+  de_backend \
+  clang-format -i $target
+
+git add $host_path
+
+echo "pre-commit format is finished"


### PR DESCRIPTION
## 変更内容
- コミット時にbackendコンテナでステージングされてるc,hファイルをフォーマット
- makeの依存関係に.git/hooks内のスクリプトを追加

## なぜ変更したか
- macとlinuxでclang-formatのバージョンが合わないことがままあるのでフォーマットの環境をコンテナに統一したい

## 動作確認の方法、動作確認した内容
- make後、c,hファイルに不要なインデントなどを追加してコミットを試す

## その他、レビューで確認してほしいことなど
