### PR TITLE
m1 で 動作するようにする

### DIFF
--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -32,8 +32,9 @@ all: $(NAME) $(TARGET)
 $(NAME): $(OBJS) Makefile
 	$(CC) $(CFLAGS) $(INCLUDE) $(OBJS) $(LIBS) -o $(NAME)
 
+# -mno-red-zone
 $(TARGET): target.c Makefile
-	$(CC) $(CFLAGS) -no-pie -mno-red-zone -g3 -o $(TARGET) target.c
+	$(CC) $(CFLAGS) -no-pie -g3 -o $(TARGET) target.c
 
 $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c Makefile
 	mkdir -p $(@D)

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -7,6 +7,12 @@ CFLAGS			:=		-Wall -Wextra -Werror -MMD -MP
 INCLUDE			:=		-I include
 LIBS			:=		-lreadline
 
+UNAME_M			:=		$(shell uname -m)
+
+ifeq ($(UNAME_M), aarch64)
+CFLAGS			+=		-D IS_ARM=1
+endif
+
 # SRCS
 # ------------------------------------------------------------------------------------------
 SRCS_DIR		:=		src

--- a/backend/app/Makefile
+++ b/backend/app/Makefile
@@ -34,7 +34,7 @@ $(NAME): $(OBJS) Makefile
 
 # -mno-red-zone
 $(TARGET): target.c Makefile
-	$(CC) $(CFLAGS) -no-pie -g3 -o $(TARGET) target.c
+	$(CC) $(CFLAGS) -no-pie -static -g3 -o $(TARGET) target.c
 
 $(OBJS_DIR)/%.o: $(SRCS_DIR)/%.c Makefile
 	mkdir -p $(@D)

--- a/backend/app/include/de.h
+++ b/backend/app/include/de.h
@@ -15,6 +15,10 @@
 
 void print_regs(pid_t pid);
 void print_regs_to_json_file(pid_t pid);
+// rip
+void set_rip(pid_t pid, unsigned long long rip);
+unsigned long long get_rip(pid_t pid);
+// rsp
 unsigned long long get_rsp(pid_t pid);
 
 void print_mem(pid_t pid, void *addr, size_t n);


### PR DESCRIPTION
## 変更内容

- m1 mac の docker イメージが `x86_64` ではなく `aarch64`
- 上記によって、何点か違う点があるので対応。
  - sigtrap の オペコードが違う (0xCC -> 0xf001f0e7)
  - user_regs_struct 構造体の変数名等が違うため対応
  - PTRACE_SETREGS の使い方 が 違うので対応
  - `-mno-red-zone` オプションがないためいったん削除
  - `-static` オプションを追加

## なぜ変更したか

- M1 mac で docker 上 で うまく動かなかったので対応
- 参考リンク : https://github.com/docker/for-mac/issues/5191#issuecomment-821319621

## 動作確認の方法、動作確認した内容

## その他、レビューで確認してほしいことなど

- backend コンテナ に 入って `make` -> `s` 以降 Enter で 動くはず
- [x] Intel の方でも動かして変更内容問題ないか確認する。

